### PR TITLE
Fix Nyaplot headline

### DIFF
--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -4901,7 +4901,7 @@
     "collapsed": true
    },
    "source": [
-    "Nyaplot"
+    "### Nyaplot"
    ]
   },
   {


### PR DESCRIPTION
Change "Nyaplot" in "Integration with Ruby gems" to headline, because it should be displayed as headline in the same way of other gems.